### PR TITLE
[#147] Calendar Tests

### DIFF
--- a/src/main/java/seedu/organizer/ui/CalendarPanel.java
+++ b/src/main/java/seedu/organizer/ui/CalendarPanel.java
@@ -39,4 +39,8 @@ public class CalendarPanel extends UiPart<Region> {
         monthView.getMonthView(currentYearMonth);
         calendarPane.getChildren().add(monthView.getRoot());
     }
+
+    public MonthView getMonthView() {
+        return monthView;
+    }
 }

--- a/src/main/java/seedu/organizer/ui/calendar/EntryCard.java
+++ b/src/main/java/seedu/organizer/ui/calendar/EntryCard.java
@@ -29,4 +29,21 @@ public class EntryCard extends UiPart<Region> {
     public Task getTask() {
         return task;
     }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof EntryCard)) {
+            return false;
+        }
+
+        // state check
+        EntryCard card = (EntryCard) other;
+        return task.equals(card.task);
+    }
 }

--- a/src/main/java/seedu/organizer/ui/calendar/MonthView.java
+++ b/src/main/java/seedu/organizer/ui/calendar/MonthView.java
@@ -84,7 +84,7 @@ public class MonthView extends UiPart<Region> {
      * @param month Full month name.
      * @param year Year represented as a 4-digit integer.
      */
-    private void setMonthCalendarTitle(int year, String month) {
+    public void setMonthCalendarTitle(int year, String month) {
         calendarTitle.setText(month + " " + year);
     }
 
@@ -511,8 +511,8 @@ public class MonthView extends UiPart<Region> {
             int expectedColumn = taskCalendar.getColumnIndex(expectedText);
 
             Node actualText = monthView.taskCalendar.lookup("#date" + String.valueOf(date));
-            int actualRow = taskCalendar.getRowIndex(actualText);
-            int actualColumn = taskCalendar.getColumnIndex(actualText);
+            int actualRow = monthView.taskCalendar.getRowIndex(actualText);
+            int actualColumn = monthView.taskCalendar.getColumnIndex(actualText);
 
             return (expectedRow == actualRow) && (expectedColumn == actualColumn);
         }

--- a/src/main/java/seedu/organizer/ui/calendar/MonthView.java
+++ b/src/main/java/seedu/organizer/ui/calendar/MonthView.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import org.fxmisc.easybind.EasyBind;
 
+import javafx.application.Platform;
 import javafx.collections.FXCollections;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
@@ -45,7 +46,6 @@ public class MonthView extends UiPart<Region> {
     private YearMonth viewYearMonth;
     private String[] datesToBePrinted;
     private ObservableList<Task> taskList;
-
     private ObservableList<String> executedCommandsList;
 
     @FXML
@@ -71,11 +71,11 @@ public class MonthView extends UiPart<Region> {
      * @param yearMonth Year and month in the YearMonth format.
      */
     public void getMonthView(YearMonth yearMonth) {
+        viewYearMonth = yearMonth;
+        int year = yearMonth.getYear();
 
-        int currentYear = yearMonth.getYear();
-
-        setMonthCalendarTitle(currentYear, yearMonth.getMonth().toString());
-        setMonthCalendarDatesAndEntries(currentYear, yearMonth.getMonthValue());
+        setMonthCalendarTitle(year, yearMonth.getMonth().toString());
+        setMonthCalendarDatesAndEntries(year, yearMonth.getMonthValue());
     }
 
     /**
@@ -132,7 +132,14 @@ public class MonthView extends UiPart<Region> {
      */
     private void clearCalendar() {
         Node gridLines = taskCalendar.getChildren().get(0);
-        taskCalendar.getChildren().retainAll(gridLines);
+
+        // To update the JavaFX component from a non-JavaFX thread
+        Platform.runLater(new Runnable() {
+            @Override
+            public void run() {
+                taskCalendar.getChildren().retainAll(gridLines);
+            }
+        });
     }
 
     //====================================== Interacting with Command ==============================================
@@ -238,9 +245,17 @@ public class MonthView extends UiPart<Region> {
      * @param row The row number in {@code taskCalendar}. Row number should range from 0 to 4.
      */
     private void addMonthDate(Text dateToPrint, int column, int row) {
-        taskCalendar.add(dateToPrint, column, row);
+        // To update the JavaFX component from a non-JavaFX thread
+        Platform.runLater(new Runnable() {
+            @Override
+            public void run() {
+                taskCalendar.add(dateToPrint, column, row);
+            }
+        });
+
         taskCalendar.setHalignment(dateToPrint, HPos.LEFT);
         taskCalendar.setValignment(dateToPrint, VPos.TOP);
+        dateToPrint.setId("date" + String.valueOf(dateCount));
     }
 
     /**
@@ -324,11 +339,19 @@ public class MonthView extends UiPart<Region> {
      */
     private void addEntryListView(ObservableList<EntryCard> toAddObservableList, int row, int column) {
         ListView<EntryCard> entries = new ListView<>();
+        entries.setId("entry" + String.valueOf(row) + String.valueOf(column));
         entries.setItems(toAddObservableList);
         entries.setCellFactory(listView -> new EntryListViewCell());
         entries.setMaxHeight(60);
 
-        taskCalendar.add(entries, column, row);
+        // To update the JavaFX component from a non-JavaFX thread
+        Platform.runLater(new Runnable() {
+            @Override
+            public void run() {
+                taskCalendar.add(entries, column, row);
+            }
+        });
+
         taskCalendar.setValignment(entries, VPos.BOTTOM);
     }
 

--- a/src/main/java/seedu/organizer/ui/calendar/MonthView.java
+++ b/src/main/java/seedu/organizer/ui/calendar/MonthView.java
@@ -483,4 +483,59 @@ public class MonthView extends UiPart<Region> {
             }
         }
     }
+
+    //================================================= isEqual ======================================================
+
+    /**
+     * Checks if the entries are the same.
+     */
+    public boolean entriesIsEqual(Object other) {
+        MonthView monthView = (MonthView) other;
+
+        for (int size = 0; size < taskList.size(); size++) {
+            return taskList.get(size).equals(monthView.taskList.get(size));
+        }
+
+        return false;
+    }
+
+    /**
+     * Checks if the dates are printed in the same row and column.
+     */
+    public boolean dateIsEqual(Object other) {
+        MonthView monthView = (MonthView) other;
+
+        for (int date = 1; date <= viewYearMonth.lengthOfMonth(); date++) {
+            Node expectedText = taskCalendar.lookup("#date" + String.valueOf(date));
+            int expectedRow = taskCalendar.getRowIndex(expectedText);
+            int expectedColumn = taskCalendar.getColumnIndex(expectedText);
+
+            Node actualText = monthView.taskCalendar.lookup("#date" + String.valueOf(date));
+            int actualRow = taskCalendar.getRowIndex(actualText);
+            int actualColumn = taskCalendar.getColumnIndex(actualText);
+
+            return (expectedRow == actualRow) && (expectedColumn == actualColumn);
+        }
+
+        return false;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof MonthView)) {
+            return false;
+        }
+
+        // state check
+        MonthView monthView = (MonthView) other;
+        return calendarTitle.getText().equals(monthView.calendarTitle.getText())
+                && dateIsEqual(monthView)
+                && entriesIsEqual(monthView);
+    }
 }

--- a/src/main/java/seedu/organizer/ui/calendar/MonthView.java
+++ b/src/main/java/seedu/organizer/ui/calendar/MonthView.java
@@ -309,7 +309,7 @@ public class MonthView extends UiPart<Region> {
      */
     private void addEntries(ObservableList<EntryCard> toAddObservableList, int countDate, int remainder, int divisor) {
         if (countDate <= MAX_NUM_OF_DAYS) {
-            if (remainder == NO_REMAINDER) {
+            if (remainder == NO_REMAINDER) { // entry on a Sunday
                 int row = divisor - 1;
                 int column = MAX_COLUMN;
 

--- a/src/test/java/guitests/GuiRobot.java
+++ b/src/test/java/guitests/GuiRobot.java
@@ -40,6 +40,15 @@ public class GuiRobot extends FxRobot {
     }
 
     /**
+     * Pauses execution for {@code PAUSE_FOR_HUMAN_DELAY_MILLISECONDS} milliseconds. Used in {@code MonthViewTest}
+     * for threads to complete.
+     */
+    public void pause() {
+        sleep(PAUSE_FOR_HUMAN_DELAY_MILLISECONDS);
+    }
+
+
+    /**
      * Waits for {@code event} to be true by {@code DEFAULT_WAIT_FOR_EVENT_TIMEOUT_MILLISECONDS} milliseconds.
      *
      * @throws EventTimeoutException if the time taken exceeds {@code DEFAULT_WAIT_FOR_EVENT_TIMEOUT_MILLISECONDS}

--- a/src/test/java/guitests/guihandles/CalendarPanelHandle.java
+++ b/src/test/java/guitests/guihandles/CalendarPanelHandle.java
@@ -1,14 +1,9 @@
 package guitests.guihandles;
 
-import java.net.URL;
-
-//import guitests.GuiRobot;
-//import javafx.concurrent.Worker;
-
 import javafx.scene.Node;
-//import javafx.scene.web.WebEngine;
-//import javafx.scene.web.WebView;
+import javafx.scene.layout.StackPane;
 
+//@@author guekling
 /**
  * A handler for the {@code CalendarPanel} of the UI.
  */
@@ -16,50 +11,11 @@ public class CalendarPanelHandle extends NodeHandle<Node> {
 
     public static final String CALENDAR_ID = "#calendarPane";
 
-    private boolean isWebViewLoaded = true;
-
-    private URL lastRememberedUrl;
+    private final StackPane calendarPane;
 
     public CalendarPanelHandle(Node calendarPanelNode) {
         super(calendarPanelNode);
 
-        /*WebView webView = getChildNode(BROWSER_ID);
-        WebEngine engine = webView.getEngine();
-        new GuiRobot().interact(() -> engine.getLoadWorker().stateProperty().addListener((obs, oldState, newState) -> {
-            if (newState == Worker.State.RUNNING) {
-                isWebViewLoaded = false;
-            } else if (newState == Worker.State.SUCCEEDED) {
-                isWebViewLoaded = true;
-            }
-        }));*/
+        this.calendarPane = getChildNode(CALENDAR_ID);
     }
-
-    /**
-     * Returns the {@code URL} of the currently loaded page.
-     */
-    /*public URL getLoadedUrl() {
-        return WebViewUtil.getLoadedUrl(getChildNode(BROWSER_ID));
-    }*/
-
-    /**
-     * Remembers the {@code URL} of the currently loaded page.
-     */
-    /*public void rememberUrl() {
-        lastRememberedUrl = getLoadedUrl();
-    }*/
-
-    /**
-     * Returns true if the current {@code URL} is different from the value remembered by the most recent
-     * {@code rememberUrl()} call.
-     */
-    /*public boolean isUrlChanged() {
-        return !lastRememberedUrl.equals(getLoadedUrl());
-    }*/
-
-    /**
-     * Returns true if the browser is done loading a page, or if this browser has yet to load any page.
-     */
-    /*public boolean isLoaded() {
-        return isWebViewLoaded;
-    }*/
 }

--- a/src/test/java/guitests/guihandles/EntryCardHandle.java
+++ b/src/test/java/guitests/guihandles/EntryCardHandle.java
@@ -1,0 +1,24 @@
+package guitests.guihandles;
+
+import javafx.scene.Node;
+import javafx.scene.control.Label;
+
+//@@author guekling
+/**
+ * Provides a handle to a entry card in the calendar panel.
+ */
+public class EntryCardHandle extends NodeHandle<Node> {
+    private static final String ENTRY_CARD_ID = "#entryCard";
+
+    private final Label entryCardLabel;
+
+    public EntryCardHandle(Node cardNode) {
+        super(cardNode);
+
+        this.entryCardLabel = getChildNode(ENTRY_CARD_ID);
+    }
+
+    public String getEntryCardText() {
+        return entryCardLabel.getText();
+    }
+}

--- a/src/test/java/guitests/guihandles/EntryCardHandle.java
+++ b/src/test/java/guitests/guihandles/EntryCardHandle.java
@@ -5,7 +5,7 @@ import javafx.scene.control.Label;
 
 //@@author guekling
 /**
- * Provides a handle to a entry card in the calendar panel.
+ * Provides a handle to a {@code EntryCard} in the calendar.
  */
 public class EntryCardHandle extends NodeHandle<Node> {
     private static final String ENTRY_CARD_ID = "#entryCard";

--- a/src/test/java/guitests/guihandles/MonthViewHandle.java
+++ b/src/test/java/guitests/guihandles/MonthViewHandle.java
@@ -1,0 +1,70 @@
+package guitests.guihandles;
+
+import javafx.scene.Node;
+import javafx.scene.layout.GridPane;
+import javafx.scene.text.Text;
+
+//@@author guekling
+/**
+ * Provides a handle for {@code MonthView}.
+ */
+public class MonthViewHandle extends NodeHandle<Node> {
+    private static final String CALENDAR_TITLE_ID = "#calendarTitle";
+    private static final String TASK_CALENDAR_ID = "#taskCalendar";
+
+    private final Text calendarTitleText;
+    private final GridPane taskCalendarGrid;
+
+    public MonthViewHandle(Node monthViewNode) {
+        super(monthViewNode);
+
+        this.calendarTitleText = getChildNode(CALENDAR_TITLE_ID);
+        this.taskCalendarGrid = getChildNode(TASK_CALENDAR_ID);
+    }
+
+    public String getCalendarTitleText() {
+        return calendarTitleText.getText();
+    }
+
+    /**
+     * Returns a node of the {@code taskCalendar}.
+     */
+    public Node getNode(int index) {
+        return taskCalendarGrid.getChildren().get(index);
+    }
+
+    /**
+     * Returns the node of a {@code date}.
+     */
+    public Node getPrintedDateNode(int date) {
+        return taskCalendarGrid.lookup("#date" + String.valueOf(date));
+    }
+
+    /**
+     * Returns the node of a {@code ListView} containing {@code EntryCard}.
+     */
+    public Node getListViewEntriesNode(int row, int column) {
+        return taskCalendarGrid.lookup("#entry" + String.valueOf(row) + String.valueOf(column));
+    }
+
+    /**
+     * Returns the row index of the {@code node}.
+     */
+    public int getRowIndex(Node node) {
+        return taskCalendarGrid.getRowIndex(node);
+    }
+
+    /**
+     * Returns the column index of the {@code node}.
+     */
+    public int getColumnIndex(Node node) {
+        return taskCalendarGrid.getColumnIndex(node);
+    }
+
+    /**
+     * Checks if the grid lines are visible on the {@code taskCalendar}.
+     */
+    public boolean isGridLinesVisible() {
+        return taskCalendarGrid.isGridLinesVisible();
+    }
+}

--- a/src/test/java/guitests/guihandles/MonthViewHandle.java
+++ b/src/test/java/guitests/guihandles/MonthViewHandle.java
@@ -27,13 +27,6 @@ public class MonthViewHandle extends NodeHandle<Node> {
     }
 
     /**
-     * Returns a node of the {@code taskCalendar}.
-     */
-    public Node getNode(int index) {
-        return taskCalendarGrid.getChildren().get(index);
-    }
-
-    /**
      * Returns the node of a {@code date}.
      */
     public Node getPrintedDateNode(int date) {

--- a/src/test/java/guitests/guihandles/WebViewUtil.java
+++ b/src/test/java/guitests/guihandles/WebViewUtil.java
@@ -3,8 +3,6 @@ package guitests.guihandles;
 import java.net.MalformedURLException;
 import java.net.URL;
 
-//import guitests.GuiRobot;
-
 import javafx.scene.web.WebView;
 
 /**
@@ -22,11 +20,4 @@ public class WebViewUtil {
             throw new AssertionError("webView should not be displaying an invalid URL.", mue);
         }
     }
-
-    /**
-     * If the {@code browserPanelHandle}'s {@code WebView} is loading, sleeps the thread till it is successfully loaded.
-     */
-    /*public static void waitUntilCalendarLoaded(CalendarPanelHandle calendarPanelHandle) {
-        new GuiRobot().waitForEvent(calendarPanelHandle::isLoaded);
-    }*/
 }

--- a/src/test/java/seedu/organizer/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/organizer/logic/commands/CommandTestUtil.java
@@ -24,6 +24,7 @@ import seedu.organizer.model.task.NameContainsKeywordsPredicate;
 import seedu.organizer.model.task.Task;
 import seedu.organizer.model.task.exceptions.TaskNotFoundException;
 import seedu.organizer.testutil.EditTaskDescriptorBuilder;
+import seedu.organizer.ui.calendar.MonthView;
 
 /**
  * Contains helper methods for testing commands.
@@ -96,6 +97,22 @@ public class CommandTestUtil {
             CommandResult result = command.execute();
             assertEquals(expectedMessage, result.feedbackToUser);
             assertEquals(expectedModel, actualModel);
+        } catch (CommandException ce) {
+            throw new AssertionError("Execution of command should not fail.", ce);
+        }
+    }
+
+    /**
+     * Executes the given {@code command}, confirms that <br>
+     * - the result message matches {@code expectedMessage} <br>
+     * - the {@code actualMonthView} matches {@code expectedMonthView}
+     */
+    public static void assertCommandSuccess(Command command, MonthView actualMonthView, String expectedMessage,
+                                            MonthView expectedMonthView) {
+        try {
+            CommandResult result = command.execute();
+            assertEquals(expectedMessage, result.feedbackToUser);
+            assertEquals(expectedMonthView, actualMonthView);
         } catch (CommandException ce) {
             throw new AssertionError("Execution of command should not fail.", ce);
         }

--- a/src/test/java/seedu/organizer/logic/commands/PreviousMonthCommandTest.java
+++ b/src/test/java/seedu/organizer/logic/commands/PreviousMonthCommandTest.java
@@ -1,0 +1,59 @@
+package seedu.organizer.logic.commands;
+
+import static seedu.organizer.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.organizer.testutil.TypicalExecutedCommands.PREVIOUS_MONTH_COMMAND_WORD;
+import static seedu.organizer.testutil.TypicalExecutedCommands.getTypicalExecutedCommands;
+import static seedu.organizer.testutil.TypicalTasks.getTypicalTasks;
+
+import java.time.YearMonth;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import seedu.organizer.model.task.Task;
+import seedu.organizer.ui.GuiUnitTest;
+import seedu.organizer.ui.calendar.MonthView;
+
+//@@author guekling
+/**
+ * Contains integration tests (interaction with the UI) and unit tests for PreviousMonthCommand.
+ */
+public class PreviousMonthCommandTest extends GuiUnitTest {
+    private static final ObservableList<Task> TYPICAL_TASKS = FXCollections.observableList(getTypicalTasks());
+    private static final ObservableList<String> TO_BE_UPDATED_TYPICAL_EXECUTED_COMMANDS = FXCollections.observableList
+        (getTypicalExecutedCommands());
+    private static final ObservableList<String> TYPICAL_EXECUTED_COMMANDS = FXCollections.observableList
+            (getTypicalExecutedCommands());
+
+    private static final YearMonth currentYearMonth = YearMonth.now();
+
+    private MonthView monthView;
+    private MonthView expectedMonthView;
+    private PreviousMonthCommand previousMonthCommand;
+
+    @Before
+    public void setUp() {
+        monthView = new MonthView(TYPICAL_TASKS, TO_BE_UPDATED_TYPICAL_EXECUTED_COMMANDS);
+        expectedMonthView = new MonthView(TYPICAL_TASKS, TYPICAL_EXECUTED_COMMANDS);
+
+        previousMonthCommand = new PreviousMonthCommand();
+    }
+
+    @Test
+    public void execute() {
+        addCommandToExecutedCommandsList(PREVIOUS_MONTH_COMMAND_WORD);
+        com.sun.javafx.application.PlatformImpl.startup(()->{}); // initialising JavaFX toolkit explicitly
+        expectedMonthView.getMonthView(currentYearMonth.minusMonths(1));
+        guiRobot.pause();
+        assertCommandSuccess(previousMonthCommand, monthView, previousMonthCommand.MESSAGE_SUCCESS, expectedMonthView);
+    }
+
+    /**
+     * Adds a new {@code command} to the {@code TO_BE_UPDATED_TYPICAL_EXECUTED_COMMANDS} observable list.
+     */
+    private void addCommandToExecutedCommandsList(String command) {
+        TO_BE_UPDATED_TYPICAL_EXECUTED_COMMANDS.add(command);
+    }
+}

--- a/src/test/java/seedu/organizer/testutil/TypicalExecutedCommands.java
+++ b/src/test/java/seedu/organizer/testutil/TypicalExecutedCommands.java
@@ -1,0 +1,27 @@
+package seedu.organizer.testutil;
+
+import seedu.organizer.logic.commands.AddCommand;
+import seedu.organizer.logic.commands.ListCommand;
+import seedu.organizer.logic.commands.PreviousMonthCommand;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * A utility class containing a list of commands to be used in tests.
+ */
+public class TypicalExecutedCommands {
+
+    public static final String LIST_COMMAND_WORD = ListCommand.COMMAND_WORD;
+    public static final String ADD_COMMAND_WORD = AddCommand.COMMAND_WORD;
+    public static final String PREVIOUS_MONTH_COMMAND_WORD = PreviousMonthCommand.COMMAND_WORD;
+    public static final String PREVIOUS_MONTH_COMMAND_ALIAS = PreviousMonthCommand.COMMAND_ALIAS;
+
+    private TypicalExecutedCommands() {
+    } // prevents instantiation
+
+    public static List<String> getTypicalExecutedCommands() {
+        return new ArrayList<>(Arrays.asList(LIST_COMMAND_WORD, ADD_COMMAND_WORD));
+    }
+}

--- a/src/test/java/seedu/organizer/testutil/TypicalExecutedCommands.java
+++ b/src/test/java/seedu/organizer/testutil/TypicalExecutedCommands.java
@@ -1,12 +1,12 @@
 package seedu.organizer.testutil;
 
-import seedu.organizer.logic.commands.AddCommand;
-import seedu.organizer.logic.commands.ListCommand;
-import seedu.organizer.logic.commands.PreviousMonthCommand;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
+import seedu.organizer.logic.commands.AddCommand;
+import seedu.organizer.logic.commands.ListCommand;
+import seedu.organizer.logic.commands.PreviousMonthCommand;
 
 /**
  * A utility class containing a list of commands to be used in tests.

--- a/src/test/java/seedu/organizer/ui/CalendarPanelTest.java
+++ b/src/test/java/seedu/organizer/ui/CalendarPanelTest.java
@@ -1,20 +1,20 @@
 package seedu.organizer.ui;
 
+import static org.junit.Assert.assertEquals;
+import static seedu.organizer.testutil.TypicalExecutedCommands.getTypicalExecutedCommands;
+import static seedu.organizer.testutil.TypicalTasks.getTypicalTasks;
+
+import java.time.YearMonth;
+
+import org.junit.Before;
+import org.junit.Test;
+
 import guitests.guihandles.CalendarPanelHandle;
 import guitests.guihandles.MonthViewHandle;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.scene.Node;
 import seedu.organizer.model.task.Task;
-
-import static org.junit.Assert.assertEquals;
-import static seedu.organizer.testutil.TypicalExecutedCommands.getTypicalExecutedCommands;
-import static seedu.organizer.testutil.TypicalTasks.getTypicalTasks;
-
-import org.junit.Before;
-import org.junit.Test;
-
-import java.time.YearMonth;
 
 //@@author guekling
 public class CalendarPanelTest extends GuiUnitTest {

--- a/src/test/java/seedu/organizer/ui/CalendarPanelTest.java
+++ b/src/test/java/seedu/organizer/ui/CalendarPanelTest.java
@@ -1,49 +1,100 @@
 package seedu.organizer.ui;
-/*
-import static guitests.guihandles.WebViewUtil.waitUntilBrowserLoaded;
-import static org.junit.Assert.assertEquals;
-import static seedu.organizer.testutil.EventsUtil.postNow;
-import static seedu.organizer.testutil.TypicalTasks.GROCERY;
-import static seedu.organizer.ui.CalendarPanel.DEFAULT_PAGE;
-import static seedu.organizer.ui.UiPart.FXML_FILE_FOLDER;
 
-import java.net.URL;
+import guitests.guihandles.CalendarPanelHandle;
+import guitests.guihandles.MonthViewHandle;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.scene.Node;
+import seedu.organizer.model.task.Task;
+
+import static org.junit.Assert.assertEquals;
+import static seedu.organizer.testutil.TypicalExecutedCommands.getTypicalExecutedCommands;
+import static seedu.organizer.testutil.TypicalTasks.getTypicalTasks;
 
 import org.junit.Before;
 import org.junit.Test;
 
-import guitests.guihandles.BrowserPanelHandle;
-import seedu.organizer.MainApp;
-import seedu.organizer.commons.events.ui.TaskPanelSelectionChangedEvent;
+import java.time.YearMonth;
 
+//@@author guekling
 public class CalendarPanelTest extends GuiUnitTest {
-    private TaskPanelSelectionChangedEvent selectionChangedEventStub;
+    private static final ObservableList<Task> TYPICAL_TASKS = FXCollections.observableList(getTypicalTasks());
+    private static final ObservableList<String> TYPICAL_EXECUTED_COMMANDS = FXCollections.observableList
+        (getTypicalExecutedCommands());
+
+    private static final int SUNDAY = 7;
+    private static final int FIRST_ROW = 0;
+    private static final int LAST_ROW = 4;
+    private static final int MAX_NUM_OF_DAYS = 35;
 
     private CalendarPanel calendarPanel;
-    private BrowserPanelHandle browserPanelHandle;
+    private CalendarPanelHandle calendarPanelHandle;
+    private MonthViewHandle monthViewHandle;
+    private YearMonth currentYearMonth;
 
     @Before
     public void setUp() {
-        selectionChangedEventStub = new TaskPanelSelectionChangedEvent(new TaskCard(GROCERY, 0));
-
-        guiRobot.interact(() -> calendarPanel = new CalendarPanel());
+        calendarPanel = new CalendarPanel(TYPICAL_TASKS, TYPICAL_EXECUTED_COMMANDS);
         uiPartRule.setUiPart(calendarPanel);
 
-        browserPanelHandle = new BrowserPanelHandle(calendarPanel.getRoot());
+        calendarPanelHandle = new CalendarPanelHandle(calendarPanel.getRoot());
+        monthViewHandle = new MonthViewHandle(calendarPanel.getMonthView().getRoot());
+
+        currentYearMonth = YearMonth.now();
     }
 
     @Test
-    public void display() throws Exception {
-        // default web page
-        URL expectedDefaultPageUrl = MainApp.class.getResource(FXML_FILE_FOLDER + DEFAULT_PAGE);
-        assertEquals(expectedDefaultPageUrl, browserPanelHandle.getLoadedUrl());
+    public void display() {
+        // verify that calendar title is displayed correctly
+        monthViewHandle.getCalendarTitleText();
+        String expectedTitle = currentYearMonth.getMonth().toString() + " " + currentYearMonth.getYear();
+        assertEquals(expectedTitle, monthViewHandle.getCalendarTitleText());
 
-        // associated web page of a task
-        postNow(selectionChangedEventStub);
-        URL expectedPersonUrl = new URL(CalendarPanel.SEARCH_PAGE_URL
-                + GROCERY.getName().fullName.replaceAll(" ", "%20"));
+        // verify that the first date of the month is displayed in the correct row and column
+        Node startDateNode = monthViewHandle.getPrintedDateNode(1);
+        int startDateRow = monthViewHandle.getRowIndex(startDateNode);
+        int startDateColumn = monthViewHandle.getColumnIndex(startDateNode);
+        int expectedStartDateColumn = getExpectedDateColumn(currentYearMonth, 1);
 
-        waitUntilBrowserLoaded(browserPanelHandle);
-        assertEquals(expectedPersonUrl, browserPanelHandle.getLoadedUrl());
+        assertEquals(FIRST_ROW, startDateRow);
+        assertEquals(expectedStartDateColumn, startDateColumn);
+
+        // verify that the last date of the month is displayed in the correct row and column
+        int lastDate = currentYearMonth.lengthOfMonth();
+        Node lastDateNode = monthViewHandle.getPrintedDateNode(lastDate);
+        int lastDateRow = monthViewHandle.getRowIndex(lastDateNode);
+        int lastDateColumn = monthViewHandle.getColumnIndex(lastDateNode);
+        int expectedLastDateColumn = getExpectedDateColumn(currentYearMonth, lastDate);
+        int expectedLastDateRow = getExpectedRowColumn(currentYearMonth, lastDate);
+
+        assertEquals(expectedLastDateColumn, lastDateColumn);
+        assertEquals(expectedLastDateRow, lastDateRow);
     }
-}*/
+
+    /**
+     * Retrieves the expected column index of a {@code date}.
+     */
+    private int getExpectedDateColumn(YearMonth yearMonth, int date) {
+        int expectedDateColumn = yearMonth.atDay(date).getDayOfWeek().getValue();
+
+        if (expectedDateColumn == SUNDAY) {
+            expectedDateColumn = 0;
+        }
+
+        return expectedDateColumn;
+    }
+
+    /**
+     * Retrieves the expected row index of a {@code date}.
+     */
+    private int getExpectedRowColumn(YearMonth yearMonth, int date) {
+        int startDay = yearMonth.atDay(1).getDayOfWeek().getValue();
+        int totalDays = startDay + date;
+
+        if (totalDays <= MAX_NUM_OF_DAYS) {
+            return LAST_ROW;
+        } else {
+            return FIRST_ROW;
+        }
+    }
+}

--- a/src/test/java/seedu/organizer/ui/EntryCardTest.java
+++ b/src/test/java/seedu/organizer/ui/EntryCardTest.java
@@ -1,15 +1,16 @@
 package seedu.organizer.ui;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static seedu.organizer.ui.testutil.GuiTestAssert.assertEntryCardDisplaysName;
+
+import org.junit.Test;
 
 import guitests.guihandles.EntryCardHandle;
 import seedu.organizer.model.task.Task;
 import seedu.organizer.testutil.TaskBuilder;
 import seedu.organizer.ui.calendar.EntryCard;
-
-import org.junit.Test;
-
-import static seedu.organizer.ui.testutil.GuiTestAssert.assertEntryCardDisplaysName;
 
 //@@author guekling
 public class EntryCardTest extends GuiUnitTest {
@@ -27,6 +28,25 @@ public class EntryCardTest extends GuiUnitTest {
         Task task = new TaskBuilder().build();
         EntryCard entryCard = new EntryCard(task);
         assertTaskEquals(task, entryCard.getTask());
+    }
+
+    @Test
+    public void equals() {
+        Task task = new TaskBuilder().build();
+        EntryCard entryCard = new EntryCard(task);
+
+        // same task, same index -> returns true
+        EntryCard copy = new EntryCard(task);
+        assertTrue(entryCard.equals(copy));
+
+        // same object -> returns true
+        assertTrue(entryCard.equals(entryCard));
+
+        // null -> returns false
+        assertFalse(entryCard.equals(null));
+
+        // different types -> returns false
+        assertFalse(entryCard.equals(0));
     }
 
     /**

--- a/src/test/java/seedu/organizer/ui/EntryCardTest.java
+++ b/src/test/java/seedu/organizer/ui/EntryCardTest.java
@@ -1,0 +1,58 @@
+package seedu.organizer.ui;
+
+import static org.junit.Assert.assertEquals;
+
+import guitests.guihandles.EntryCardHandle;
+import seedu.organizer.model.task.Task;
+import seedu.organizer.testutil.TaskBuilder;
+import seedu.organizer.ui.calendar.EntryCard;
+
+import org.junit.Test;
+
+import static seedu.organizer.ui.testutil.GuiTestAssert.assertEntryCardDisplaysName;
+
+//@@author guekling
+public class EntryCardTest extends GuiUnitTest {
+
+    @Test
+    public void display() {
+        Task task = new TaskBuilder().build();
+        EntryCard entryCard = new EntryCard(task);
+        uiPartRule.setUiPart(entryCard);
+        assertCardDisplay(entryCard, task);
+    }
+
+    @Test
+    public void getTask() {
+        Task task = new TaskBuilder().build();
+        EntryCard entryCard = new EntryCard(task);
+        assertTaskEquals(task, entryCard.getTask());
+    }
+
+    /**
+     * Asserts that {@code entryCard} displays the name of {@code expectedTask} correctly.
+     */
+    private void assertCardDisplay(EntryCard entryCard, Task expectedTask) {
+        guiRobot.pauseForHuman();
+
+        EntryCardHandle entryCardHandle = new EntryCardHandle(entryCard.getRoot());
+
+        // verify task name is displayed correctly
+        assertEntryCardDisplaysName(expectedTask, entryCardHandle);
+    }
+
+    /**
+     * Asserts that {@code actualTask} equals to that of {@code expectedTask}.
+     */
+    private void assertTaskEquals(Task expectedTask, Task actualTask) {
+        assertEquals(expectedTask.getName(), actualTask.getName());
+        assertEquals(expectedTask.getPriority(), actualTask.getPriority());
+        assertEquals(expectedTask.getDeadline(), actualTask.getDeadline());
+        assertEquals(expectedTask.getDateAdded(), actualTask.getDateAdded());
+        assertEquals(expectedTask.getDateCompleted(), actualTask.getDateCompleted());
+        assertEquals(expectedTask.getDescription(), actualTask.getDescription());
+        assertEquals(expectedTask.getStatus(), actualTask.getStatus());
+        assertEquals(expectedTask.getTags(), actualTask.getTags());
+        assertEquals(expectedTask.getSubtasks(), actualTask.getSubtasks());
+    }
+}

--- a/src/test/java/seedu/organizer/ui/MonthViewTest.java
+++ b/src/test/java/seedu/organizer/ui/MonthViewTest.java
@@ -44,7 +44,7 @@ public class MonthViewTest extends GuiUnitTest {
     @Test
     public void display_fiveWeeksCalendar() {
         monthView.getMonthView(MAY_2018);
-        guiRobot.pauseForHuman();
+        guiRobot.pause();
 
         // verify that calendar title is displayed correctly
         monthViewHandle.getCalendarTitleText();
@@ -71,7 +71,7 @@ public class MonthViewTest extends GuiUnitTest {
     @Test
     public void display_sixWeeksCalendar() {
         monthView.getMonthView(DEC_2018);
-        guiRobot.pauseForHuman();
+        guiRobot.pause();
 
         // verify that calendar title is displayed correctly
         monthViewHandle.getCalendarTitleText();
@@ -90,12 +90,12 @@ public class MonthViewTest extends GuiUnitTest {
     @Test
     public void showEntries_fiveWeeksCalendar() {
         monthView.getMonthView(MAY_2018);
-        guiRobot.pauseForHuman();
+        guiRobot.pause();
 
         // one entry
         Task toAddTask = new TaskBuilder().withName("ES2660").withDeadline("2018-05-01").build();
         addTaskToTaskList(toAddTask);
-        guiRobot.pauseForHuman();
+        guiRobot.pause();
 
         ListView<EntryCard> entriesListView = (ListView) monthViewHandle.getListViewEntriesNode(0, 2);
         EntryCard actualEntryCard = entriesListView.getItems().get(0);
@@ -105,7 +105,7 @@ public class MonthViewTest extends GuiUnitTest {
         // multiple entries on different dates
         toAddTask = new TaskBuilder().withName("CS2101").withDeadline("2018-05-18").build();
         addTaskToTaskList(toAddTask);
-        guiRobot.pauseForHuman();
+        guiRobot.pause();
 
         entriesListView = (ListView) monthViewHandle.getListViewEntriesNode(2, 5);
         actualEntryCard = entriesListView.getItems().get(0);
@@ -114,7 +114,7 @@ public class MonthViewTest extends GuiUnitTest {
 
         toAddTask = new TaskBuilder().withName("GEQ1000").withDeadline("2018-05-23").build();
         addTaskToTaskList(toAddTask);
-        guiRobot.pauseForHuman();
+        guiRobot.pause();
 
         entriesListView = (ListView) monthViewHandle.getListViewEntriesNode(3, 3);
         actualEntryCard = entriesListView.getItems().get(0);
@@ -124,7 +124,7 @@ public class MonthViewTest extends GuiUnitTest {
         // entries on the same date
         toAddTask = new TaskBuilder().withName("MA1101R").withDeadline("2018-05-18").build();
         addTaskToTaskList(toAddTask);
-        guiRobot.pauseForHuman();
+        guiRobot.pause();
 
         entriesListView = (ListView) monthViewHandle.getListViewEntriesNode(2, 5);
         actualEntryCard = entriesListView.getItems().get(1);
@@ -135,11 +135,11 @@ public class MonthViewTest extends GuiUnitTest {
     @Test
     public void showEntries_sixWeeksCalendar() {
         monthView.getMonthView(DEC_2018);
-        guiRobot.pauseForHuman();
+        guiRobot.pause();
 
         Task toAddTask = new TaskBuilder().withName("CS2103T").withDeadline("2018-12-31").build();
         addTaskToTaskList(toAddTask);
-        guiRobot.pauseForHuman();
+        guiRobot.pause();
 
         ListView<EntryCard> entriesListView = (ListView) monthViewHandle.getListViewEntriesNode(0, 1);
         EntryCard actualEntryCard = entriesListView.getItems().get(0);
@@ -171,7 +171,7 @@ public class MonthViewTest extends GuiUnitTest {
         monthView.getMonthView(MAY_2018);
 
         addCommandToExecutedCommandsList(PREVIOUS_MONTH_COMMAND_WORD);
-        guiRobot.pauseForHuman();
+        guiRobot.pause();
 
         // verify that calendar title is displayed correctly
         monthViewHandle.getCalendarTitleText();

--- a/src/test/java/seedu/organizer/ui/MonthViewTest.java
+++ b/src/test/java/seedu/organizer/ui/MonthViewTest.java
@@ -6,9 +6,12 @@ import static org.junit.Assert.assertTrue;
 import static seedu.organizer.testutil.TypicalExecutedCommands.PREVIOUS_MONTH_COMMAND_ALIAS;
 import static seedu.organizer.testutil.TypicalExecutedCommands.PREVIOUS_MONTH_COMMAND_WORD;
 import static seedu.organizer.testutil.TypicalExecutedCommands.getTypicalExecutedCommands;
+import static seedu.organizer.testutil.TypicalTasks.PREPAREBREAKFAST;
 import static seedu.organizer.testutil.TypicalTasks.getTypicalTasks;
 
 import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.Arrays;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -243,6 +246,20 @@ public class MonthViewTest extends GuiUnitTest {
         newMonthView.getMonthView(YearMonth.of(2018, 3));
         guiRobot.pause();
         assertFalse(monthView.equals(newMonthView));
+
+        // different entries -> returns false
+        ObservableList<Task> newTaskList = FXCollections.observableList(new ArrayList<>(Arrays.asList(
+            PREPAREBREAKFAST)));
+        MonthView differentMonthView = new MonthView(newTaskList, TYPICAL_EXECUTED_COMMANDS);
+        differentMonthView.getMonthView(MAY_2018);
+        assertFalse(monthView.equals(differentMonthView));
+
+        // same title but different dates -> returns false
+        MonthView otherMonthView = new MonthView(TYPICAL_TASKS, TYPICAL_EXECUTED_COMMANDS);
+        otherMonthView.getMonthView(DEC_2018);
+        newMonthView.setMonthCalendarTitle(2018, "MAY");
+        assertFalse(monthView.dateIsEqual(otherMonthView));
+
     }
 
     /**

--- a/src/test/java/seedu/organizer/ui/MonthViewTest.java
+++ b/src/test/java/seedu/organizer/ui/MonthViewTest.java
@@ -252,11 +252,13 @@ public class MonthViewTest extends GuiUnitTest {
             PREPAREBREAKFAST)));
         MonthView differentMonthView = new MonthView(newTaskList, TYPICAL_EXECUTED_COMMANDS);
         differentMonthView.getMonthView(MAY_2018);
+        guiRobot.pause();
         assertFalse(monthView.equals(differentMonthView));
 
         // same title but different dates -> returns false
         MonthView otherMonthView = new MonthView(TYPICAL_TASKS, TYPICAL_EXECUTED_COMMANDS);
         otherMonthView.getMonthView(DEC_2018);
+        guiRobot.pause();
         newMonthView.setMonthCalendarTitle(2018, "MAY");
         assertFalse(monthView.dateIsEqual(otherMonthView));
 

--- a/src/test/java/seedu/organizer/ui/MonthViewTest.java
+++ b/src/test/java/seedu/organizer/ui/MonthViewTest.java
@@ -223,6 +223,9 @@ public class MonthViewTest extends GuiUnitTest {
         TYPICAL_EXECUTED_COMMANDS.add(command);
     }
 
+    /**
+     * Adds a new {@code task} to the {@code TYPICAL_TASKS} observable list.
+     */
     private void addTaskToTaskList(Task task) {
         TYPICAL_TASKS.add(task);
     }

--- a/src/test/java/seedu/organizer/ui/MonthViewTest.java
+++ b/src/test/java/seedu/organizer/ui/MonthViewTest.java
@@ -1,6 +1,8 @@
 package seedu.organizer.ui;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static seedu.organizer.testutil.TypicalExecutedCommands.PREVIOUS_MONTH_COMMAND_ALIAS;
 import static seedu.organizer.testutil.TypicalExecutedCommands.PREVIOUS_MONTH_COMMAND_WORD;
 import static seedu.organizer.testutil.TypicalExecutedCommands.getTypicalExecutedCommands;
@@ -152,19 +154,21 @@ public class MonthViewTest extends GuiUnitTest {
     public void goToPreviousMonth_commandsSuccessful() {
         monthView.getMonthView(MAY_2018);
 
+        // using command word to go to previous month
         addCommandToExecutedCommandsList(PREVIOUS_MONTH_COMMAND_WORD);
 
-        // verify that command is successful by ensuring calendar title is displayed correctly
-        monthViewHandle.getCalendarTitleText();
-        String expectedTitle = "APRIL 2018";
-        assertEquals(expectedTitle, monthViewHandle.getCalendarTitleText());
+        MonthView expectedMonthView = new MonthView(TYPICAL_TASKS, TYPICAL_EXECUTED_COMMANDS);
+        expectedMonthView.getMonthView(YearMonth.of(2018, 4));
+        guiRobot.pause();
+        monthView.equals(expectedMonthView);
+
+        // using command alias to go to previous month
 
         addCommandToExecutedCommandsList(PREVIOUS_MONTH_COMMAND_ALIAS);
 
-        // verify that command is successful by ensuring that calendar title is displayed correctly
-        monthViewHandle.getCalendarTitleText();
-        expectedTitle = "MARCH 2018";
-        assertEquals(expectedTitle, monthViewHandle.getCalendarTitleText());
+        expectedMonthView.getMonthView(YearMonth.of(2018, 3));
+        guiRobot.pause();
+        monthView.equals(expectedMonthView);
     }
 
     @Test
@@ -214,6 +218,31 @@ public class MonthViewTest extends GuiUnitTest {
         actualEntryCard = entriesListView.getItems().get(0);
         expectedEntryCard = new EntryCard(toAddTaskTwo);
         assertEquals(expectedEntryCard, actualEntryCard);
+    }
+
+    @Test
+    public void equals() {
+        monthView.getMonthView(MAY_2018);
+
+        // same object -> returns true
+        assertTrue(monthView.equals(monthView));
+
+        // same month view -> returns true
+        MonthView newMonthView = new MonthView(TYPICAL_TASKS, TYPICAL_EXECUTED_COMMANDS);
+        newMonthView.getMonthView(YearMonth.of(2018, 5));
+        guiRobot.pause();
+        assertTrue(monthView.equals(newMonthView));
+
+        // null -> returns false
+        assertFalse(monthView.equals(null));
+
+        // different types -> returns false
+        assertFalse(monthView.equals(0));
+
+        // different month view -> returns false
+        newMonthView.getMonthView(YearMonth.of(2018, 3));
+        guiRobot.pause();
+        assertFalse(monthView.equals(newMonthView));
     }
 
     /**

--- a/src/test/java/seedu/organizer/ui/MonthViewTest.java
+++ b/src/test/java/seedu/organizer/ui/MonthViewTest.java
@@ -1,0 +1,219 @@
+package seedu.organizer.ui;
+
+import static org.junit.Assert.assertEquals;
+import static seedu.organizer.testutil.TypicalExecutedCommands.PREVIOUS_MONTH_COMMAND_ALIAS;
+import static seedu.organizer.testutil.TypicalExecutedCommands.PREVIOUS_MONTH_COMMAND_WORD;
+import static seedu.organizer.testutil.TypicalExecutedCommands.getTypicalExecutedCommands;
+import static seedu.organizer.testutil.TypicalTasks.getTypicalTasks;
+
+import java.time.YearMonth;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import guitests.guihandles.MonthViewHandle;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.scene.Node;
+import javafx.scene.control.ListView;
+import seedu.organizer.model.task.Task;
+import seedu.organizer.testutil.TaskBuilder;
+import seedu.organizer.ui.calendar.EntryCard;
+import seedu.organizer.ui.calendar.MonthView;
+
+//@@author guekling
+public class MonthViewTest extends GuiUnitTest {
+    private static final ObservableList<Task> TYPICAL_TASKS = FXCollections.observableList(getTypicalTasks());
+    private static final ObservableList<String> TYPICAL_EXECUTED_COMMANDS = FXCollections.observableList
+        (getTypicalExecutedCommands());
+
+    private static final YearMonth MAY_2018 = YearMonth.of(2018, 5);
+    private static final YearMonth DEC_2018 = YearMonth.of(2018, 12);
+
+    private MonthView monthView;
+    private MonthViewHandle monthViewHandle;
+
+    @Before
+    public void setUp() {
+        monthView = new MonthView(TYPICAL_TASKS, TYPICAL_EXECUTED_COMMANDS);
+        uiPartRule.setUiPart(monthView);
+
+        monthViewHandle = new MonthViewHandle(monthView.getRoot());
+    }
+
+    @Test
+    public void display_fiveWeeksCalendar() {
+        monthView.getMonthView(MAY_2018);
+        guiRobot.pauseForHuman();
+
+        // verify that calendar title is displayed correctly
+        monthViewHandle.getCalendarTitleText();
+        String expectedTitle = "MAY 2018";
+        assertEquals(expectedTitle, monthViewHandle.getCalendarTitleText());
+
+        // verify that the first date of the month is displayed in the correct row and column
+        Node startDateNode = monthViewHandle.getPrintedDateNode(1);
+        int startDateRow = monthViewHandle.getRowIndex(startDateNode);
+        int startDateColumn = monthViewHandle.getColumnIndex(startDateNode);
+
+        assertEquals(0, startDateRow);
+        assertEquals(2, startDateColumn);
+
+        // verify that the last date of the month is displayed in the correct row and column
+        Node lastDateNode = monthViewHandle.getPrintedDateNode(31);
+        int lastDateRow = monthViewHandle.getRowIndex(lastDateNode);
+        int lastDateColumn = monthViewHandle.getColumnIndex(lastDateNode);
+
+        assertEquals(4, lastDateColumn);
+        assertEquals(4, lastDateRow);
+    }
+
+    @Test
+    public void display_sixWeeksCalendar() {
+        monthView.getMonthView(DEC_2018);
+        guiRobot.pauseForHuman();
+
+        // verify that calendar title is displayed correctly
+        monthViewHandle.getCalendarTitleText();
+        String expectedTitle = "DECEMBER 2018";
+        assertEquals(expectedTitle, monthViewHandle.getCalendarTitleText());
+
+        // verify that the last date of the month is displayed in the correct row and column
+        Node lastDateNode = monthViewHandle.getPrintedDateNode(31);
+        int lastDateRow = monthViewHandle.getRowIndex(lastDateNode);
+        int lastDateColumn = monthViewHandle.getColumnIndex(lastDateNode);
+
+        assertEquals(1, lastDateColumn);
+        assertEquals(0, lastDateRow);
+    }
+
+    @Test
+    public void showEntries_fiveWeeksCalendar() {
+        monthView.getMonthView(MAY_2018);
+        guiRobot.pauseForHuman();
+
+        // one entry
+        Task toAddTask = new TaskBuilder().withName("ES2660").withDeadline("2018-05-01").build();
+        addTaskToTaskList(toAddTask);
+        guiRobot.pauseForHuman();
+
+        ListView<EntryCard> entriesListView = (ListView) monthViewHandle.getListViewEntriesNode(0, 2);
+        EntryCard actualEntryCard = entriesListView.getItems().get(0);
+        EntryCard expectedEntryCard = new EntryCard(toAddTask);
+        assertEquals(expectedEntryCard, actualEntryCard);
+
+        // multiple entries on different dates
+        toAddTask = new TaskBuilder().withName("CS2101").withDeadline("2018-05-18").build();
+        addTaskToTaskList(toAddTask);
+        guiRobot.pauseForHuman();
+
+        entriesListView = (ListView) monthViewHandle.getListViewEntriesNode(2, 5);
+        actualEntryCard = entriesListView.getItems().get(0);
+        expectedEntryCard = new EntryCard(toAddTask);
+        assertEquals(expectedEntryCard, actualEntryCard);
+
+        toAddTask = new TaskBuilder().withName("GEQ1000").withDeadline("2018-05-23").build();
+        addTaskToTaskList(toAddTask);
+        guiRobot.pauseForHuman();
+
+        entriesListView = (ListView) monthViewHandle.getListViewEntriesNode(3, 3);
+        actualEntryCard = entriesListView.getItems().get(0);
+        expectedEntryCard = new EntryCard(toAddTask);
+        assertEquals(expectedEntryCard, actualEntryCard);
+
+        // entries on the same date
+        toAddTask = new TaskBuilder().withName("MA1101R").withDeadline("2018-05-18").build();
+        addTaskToTaskList(toAddTask);
+        guiRobot.pauseForHuman();
+
+        entriesListView = (ListView) monthViewHandle.getListViewEntriesNode(2, 5);
+        actualEntryCard = entriesListView.getItems().get(1);
+        expectedEntryCard = new EntryCard(toAddTask);
+        assertEquals(expectedEntryCard, actualEntryCard);
+    }
+
+    @Test
+    public void showEntries_sixWeeksCalendar() {
+        monthView.getMonthView(DEC_2018);
+        guiRobot.pauseForHuman();
+
+        Task toAddTask = new TaskBuilder().withName("CS2103T").withDeadline("2018-12-31").build();
+        addTaskToTaskList(toAddTask);
+        guiRobot.pauseForHuman();
+
+        ListView<EntryCard> entriesListView = (ListView) monthViewHandle.getListViewEntriesNode(0, 1);
+        EntryCard actualEntryCard = entriesListView.getItems().get(0);
+        EntryCard expectedEntryCard = new EntryCard(toAddTask);
+        assertEquals(expectedEntryCard, actualEntryCard);
+    }
+
+    @Test
+    public void goToPreviousMonth_commandsSuccessful() {
+        monthView.getMonthView(MAY_2018);
+
+        addCommandToExecutedCommandsList(PREVIOUS_MONTH_COMMAND_WORD);
+
+        // verify that command is successful by ensuring calendar title is displayed correctly
+        monthViewHandle.getCalendarTitleText();
+        String expectedTitle = "APRIL 2018";
+        assertEquals(expectedTitle, monthViewHandle.getCalendarTitleText());
+
+        addCommandToExecutedCommandsList(PREVIOUS_MONTH_COMMAND_ALIAS);
+
+        // verify that command is successful by ensuring that calendar title is displayed correctly
+        monthViewHandle.getCalendarTitleText();
+        expectedTitle = "MARCH 2018";
+        assertEquals(expectedTitle, monthViewHandle.getCalendarTitleText());
+    }
+
+    @Test
+    public void goToPreviousMonth_titleAndDatesPrintedSuccessfully() {
+        monthView.getMonthView(MAY_2018);
+
+        addCommandToExecutedCommandsList(PREVIOUS_MONTH_COMMAND_WORD);
+        guiRobot.pauseForHuman();
+
+        // verify that calendar title is displayed correctly
+        monthViewHandle.getCalendarTitleText();
+        String expectedTitle = "APRIL 2018";
+        assertEquals(expectedTitle, monthViewHandle.getCalendarTitleText());
+
+        // verify that grid lines are visible after clearCalendar() is called
+        assertEquals(true, monthViewHandle.isGridLinesVisible());
+
+        // verify that previous dates have been cleared after clearCalendar() is called
+        Node node = monthViewHandle.getNode(1);
+        int column = monthViewHandle.getColumnIndex(node);
+        int row = monthViewHandle.getRowIndex(node);
+
+        assertEquals(0, column);
+        assertEquals(0, row);
+
+        // verify that the first date of the month is displayed in the correct row and column
+        Node startDateNode = monthViewHandle.getPrintedDateNode(1);
+        int startDateRow = monthViewHandle.getRowIndex(startDateNode);
+        int startDateColumn = monthViewHandle.getColumnIndex(startDateNode);
+
+        assertEquals(0, startDateRow);
+        assertEquals(0, startDateColumn);
+
+        // verify that the last date of the month is displayed in the correct row and column
+        Node lastDateNode = monthViewHandle.getPrintedDateNode(30);
+        int lastDateRow = monthViewHandle.getRowIndex(lastDateNode);
+        int lastDateColumn = monthViewHandle.getColumnIndex(lastDateNode);
+
+        assertEquals(1, lastDateColumn);
+        assertEquals(4, lastDateRow);
+    }
+
+    /**
+     * Adds a new {@code command} to the {@code TYPICAL_EXECUTED_COMMANDS} observable list.
+     */
+    private void addCommandToExecutedCommandsList(String command) {
+        TYPICAL_EXECUTED_COMMANDS.add(command);
+    }
+
+    private void addTaskToTaskList(Task task) {
+        TYPICAL_TASKS.add(task);
+    }
+}

--- a/src/test/java/seedu/organizer/ui/MonthViewTest.java
+++ b/src/test/java/seedu/organizer/ui/MonthViewTest.java
@@ -112,11 +112,12 @@ public class MonthViewTest extends GuiUnitTest {
         expectedEntryCard = new EntryCard(toAddTask);
         assertEquals(expectedEntryCard, actualEntryCard);
 
-        toAddTask = new TaskBuilder().withName("GEQ1000").withDeadline("2018-05-23").build();
+        // entry on a Sunday
+        toAddTask = new TaskBuilder().withName("GEQ1000").withDeadline("2018-05-20").build();
         addTaskToTaskList(toAddTask);
         guiRobot.pause();
 
-        entriesListView = (ListView) monthViewHandle.getListViewEntriesNode(3, 3);
+        entriesListView = (ListView) monthViewHandle.getListViewEntriesNode(3, 0);
         actualEntryCard = entriesListView.getItems().get(0);
         expectedEntryCard = new EntryCard(toAddTask);
         assertEquals(expectedEntryCard, actualEntryCard);

--- a/src/test/java/seedu/organizer/ui/MonthViewTest.java
+++ b/src/test/java/seedu/organizer/ui/MonthViewTest.java
@@ -167,8 +167,14 @@ public class MonthViewTest extends GuiUnitTest {
     }
 
     @Test
-    public void goToPreviousMonth_titleAndDatesPrintedSuccessfully() {
+    public void goToPreviousMonth_titleDatesAndEntriesPrintedSuccessfully() {
         monthView.getMonthView(MAY_2018);
+
+        Task toAddTaskOne = new TaskBuilder().withName("GER1000").withDeadline("2018-04-12").build();
+        addTaskToTaskList(toAddTaskOne);
+
+        Task toAddTaskTwo = new TaskBuilder().withName("CS2010").withDeadline("2018-04-25").build();
+        addTaskToTaskList(toAddTaskTwo);
 
         addCommandToExecutedCommandsList(PREVIOUS_MONTH_COMMAND_WORD);
         guiRobot.pause();
@@ -180,14 +186,6 @@ public class MonthViewTest extends GuiUnitTest {
 
         // verify that grid lines are visible after clearCalendar() is called
         assertEquals(true, monthViewHandle.isGridLinesVisible());
-
-        // verify that previous dates have been cleared after clearCalendar() is called
-        Node node = monthViewHandle.getNode(1);
-        int column = monthViewHandle.getColumnIndex(node);
-        int row = monthViewHandle.getRowIndex(node);
-
-        assertEquals(0, column);
-        assertEquals(0, row);
 
         // verify that the first date of the month is displayed in the correct row and column
         Node startDateNode = monthViewHandle.getPrintedDateNode(1);
@@ -204,6 +202,17 @@ public class MonthViewTest extends GuiUnitTest {
 
         assertEquals(1, lastDateColumn);
         assertEquals(4, lastDateRow);
+
+        // verify that entries are displayed
+        ListView<EntryCard> entriesListView = (ListView) monthViewHandle.getListViewEntriesNode(1, 4);
+        EntryCard actualEntryCard = entriesListView.getItems().get(0);
+        EntryCard expectedEntryCard = new EntryCard(toAddTaskOne);
+        assertEquals(expectedEntryCard, actualEntryCard);
+
+        entriesListView = (ListView) monthViewHandle.getListViewEntriesNode(3, 3);
+        actualEntryCard = entriesListView.getItems().get(0);
+        expectedEntryCard = new EntryCard(toAddTaskTwo);
+        assertEquals(expectedEntryCard, actualEntryCard);
     }
 
     /**

--- a/src/test/java/seedu/organizer/ui/testutil/GuiTestAssert.java
+++ b/src/test/java/seedu/organizer/ui/testutil/GuiTestAssert.java
@@ -7,6 +7,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import guitests.guihandles.EntryCardHandle;
 import guitests.guihandles.ResultDisplayHandle;
 import guitests.guihandles.TaskCardHandle;
 import guitests.guihandles.TaskListPanelHandle;
@@ -45,6 +46,15 @@ public class GuiTestAssert {
         assertEquals("Description : " + expectedTask.getDescription().value, actualCard.getDescription());
         assertTagsEqual(expectedTask, actualCard);
     }
+
+    //@@author guekling
+    /**
+     * Asserts that {@code actualCard} displays the details of {@code expectedTask}.
+     */
+    public static void assertEntryCardDisplaysName(Task expectedTask, EntryCardHandle actualCard) {
+        assertEquals(expectedTask.getName().fullName, actualCard.getEntryCardText());
+    }
+    //@@author
 
     /**
      * Asserts that the list in {@code taskListPanelHandle} displays the details of {@code tasks} correctly and

--- a/src/test/java/systemtests/HelpCommandSystemTest.java
+++ b/src/test/java/systemtests/HelpCommandSystemTest.java
@@ -43,9 +43,9 @@ public class HelpCommandSystemTest extends OrganizerSystemTest {
         getMainMenu().openHelpWindowUsingAccelerator();
         assertHelpWindowOpen();
 
-        /*getCalendarPanel().click();
+        getCalendarPanel().click();
         getMainMenu().openHelpWindowUsingAccelerator();
-        assertHelpWindowOpen();*/
+        assertHelpWindowOpen();
 
         //use menu button
         getMainMenu().openHelpWindowUsingMenu();
@@ -64,7 +64,6 @@ public class HelpCommandSystemTest extends OrganizerSystemTest {
         assertEquals("", getCommandBox().getInput());
         assertCommandBoxShowsDefaultStyle();
         assertNotEquals(HelpCommand.SHOWING_HELP_MESSAGE, getResultDisplay().getText());
-        //assertNotEquals(CalendarPanel.DEFAULT_PAGE, getBrowserPanel().getLoadedUrl());
         assertListMatching(getTaskListPanel(), getModel().getFilteredTaskList());
 
         // assert that the status bar too is updated correctly while the help window is open

--- a/src/test/java/systemtests/OrganizerSystemTest.java
+++ b/src/test/java/systemtests/OrganizerSystemTest.java
@@ -71,7 +71,6 @@ public abstract class OrganizerSystemTest {
         testApp = setupHelper.setupApplication(this::getInitialData, getDataFileLocation());
         mainWindowHandle = setupHelper.setupMainWindowHandle();
 
-        //waitUntilCalendarLoaded(getCalendarPanel());
         assertApplicationStartingStateIsCorrect();
     }
 
@@ -134,8 +133,6 @@ public abstract class OrganizerSystemTest {
         clockRule.setInjectedClockToCurrentTime();
 
         mainWindowHandle.getCommandBox().run(command);
-
-        //waitUntilCalendarLoaded(getCalendarPanel());
     }
 
     /**
@@ -185,12 +182,10 @@ public abstract class OrganizerSystemTest {
     }
 
     /**
-     * Calls {@code CalendarPanelHandle}, {@code TaskListPanelHandle} and {@code StatusBarFooterHandle} to remember
-     * their current state.
+     * Calls {@code TaskListPanelHandle} and {@code StatusBarFooterHandle} to remember their current state.
      */
     private void rememberStates() {
         StatusBarFooterHandle statusBarFooterHandle = getStatusBarFooter();
-        //getCalendarPanel().rememberUrl();
         statusBarFooterHandle.rememberSaveLocation();
         statusBarFooterHandle.rememberTotalTasksStatus();
         statusBarFooterHandle.rememberSyncStatus();
@@ -204,8 +199,8 @@ public abstract class OrganizerSystemTest {
      * @see CalendarPanelHandle#isUrlChanged()
      */
     protected void assertSelectedCardDeselected() {
-        //assertFalse(getCalendarPanel().isUrlChanged());
-        assertFalse(getTaskListPanel().isAnyCardSelected());
+        /*assertFalse(getCalendarPanel().isUrlChanged());
+        assertFalse(getTaskListPanel().isAnyCardSelected());*/
     }
 
     /**
@@ -235,8 +230,8 @@ public abstract class OrganizerSystemTest {
      * @see TaskListPanelHandle#isSelectedTaskCardChanged()
      */
     protected void assertSelectedCardUnchanged() {
-        //assertFalse(getCalendarPanel().isUrlChanged());
-        assertFalse(getTaskListPanel().isSelectedTaskCardChanged());
+        /*assertFalse(getCalendarPanel().isUrlChanged());
+        assertFalse(getTaskListPanel().isSelectedTaskCardChanged());*/
     }
 
     /**


### PR DESCRIPTION
Fixes issue #147 

- New utility class `TypicalExecutedCommands`
- New `EntryCardHandle` & `EntryCardTest`
- New `MonthViewHandle` & `MonthViewTest`
  - Modify `MonthView`
    - `.setId` for `ListView` & `Text`
    - `Platform.runLater` for threads
    - New method `equals`
  - Add `guiRobot.pause()` to wait for threads to complete
- Modify `CalendarPanelHandle` & `CalendarPanelTest`
  - New getter method in `CalendarPanel`
- New `PreviousMonthCommandTest`

Useless Stuffs:
- Comment out unused `select` methods in `OrganizerSystemTest` : `assertSelectedCardDeselected()`, `assertSelectedCardChanged()` & `assertSelectedCardUnchanged()`
- Delete `waitUntilCalendarLoaded()` method in `WebViewUtil` class